### PR TITLE
Docker test builds are now done by docker hub

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,8 @@
 language: go
-sudo: required
+sudo: false
 
 go:
   - 1.9
-
-
 
 matrix:
   include:
@@ -19,15 +17,6 @@ matrix:
         - RELEASE_TAR=$RELEASE_DIR.tar.gz
         - BINARY_PATH=$HOME/jira-branch-helper
 
-services:
-  - docker
-
-before_install:
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then  curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add - ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then  sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then  sudo apt-get update ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then  sudo apt-get -y install docker-ce ; fi
-
 install:
 - go get -u github.com/golang/dep/cmd/dep
 - go get github.com/onsi/ginkgo/ginkgo
@@ -37,8 +26,6 @@ install:
 
 script:
   - (cd jira/branchhelper && go test)
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then docker build . ; fi
-
 
 before_deploy:
   - mkdir $RELEASE_DIR

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Changed
 - Docker version now listed as "docker" ([#7])
+- Docker test builds are now done by docker hub rather than travis ([#8])
 
 ### Added
 - Added badges to readme ([#8])
 
 [#7]: https://github.com/PurpleBooth/jira-branch-helper/pull/7
-[#7]: https://github.com/PurpleBooth/jira-branch-helper/pull/8
+[#8]: https://github.com/PurpleBooth/jira-branch-helper/pull/8
 
 ## [0.1.3] - 2017-09-29
 ### Changed


### PR DESCRIPTION
This allows the tests on travis to run in a docker container, and to
parallise the tests.