### PR TITLE
Releases are no longer in unneeded folders

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ script:
 before_deploy:
   - mkdir $RELEASE_DIR
   - cp $BINARY_PATH $RELEASE_DIR/
-  - tar cvzf $RELEASE_TAR $RELEASE_DIR
+  - tar -cvzf $RELEASE_TAR -C $RELEASE_DIR .
 deploy:
   provider: releases
   api_key:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - Docker version now listed as "docker" ([#7])
 - Docker test builds are now done by docker hub rather than travis ([#9])
+- Releases are no longer in unneeded folders ([#10])
 
 ### Added
 - Added badges to readme ([#8])
@@ -15,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 [#7]: https://github.com/PurpleBooth/jira-branch-helper/pull/7
 [#8]: https://github.com/PurpleBooth/jira-branch-helper/pull/8
 [#9]: https://github.com/PurpleBooth/jira-branch-helper/pull/9
+[#10]: https://github.com/PurpleBooth/jira-branch-helper/pull/10
 
 ## [0.1.3] - 2017-09-29
 ### Changed


### PR DESCRIPTION
We now no longer use absolute paths in releases

So

/home/travis/release-xxx-xxx/release-xxx-xxx
becomes
/release-xxx-xxx