### PR TITLE
Preparing release 0.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.1.4] - 2017-09-29
 ### Changed
 - Docker version now listed as "docker" ([#7])
 - Docker test builds are now done by docker hub rather than travis ([#9])
@@ -51,7 +53,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Initial release
 
-[Unreleased]: https://github.com/PurpleBooth/jira-branch-helper/compare/v0.1.3...HEAD
+[Unreleased]: https://github.com/PurpleBooth/jira-branch-helper/compare/v0.1.4...HEAD
+[0.1.4]: https://github.com/PurpleBooth/jira-branch-helper/compare/v0.1.3...v0.1.4
 [0.1.3]: https://github.com/PurpleBooth/jira-branch-helper/compare/v0.1.2...v0.1.3
 [0.1.2]: https://github.com/PurpleBooth/jira-branch-helper/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/PurpleBooth/jira-branch-helper/compare/v0.1.0...v0.1.1


### PR DESCRIPTION
Changed
- Docker version now listed as "docker" ([#7])
- Docker test builds are now done by docker hub rather than travis ([#9])
- Releases are no longer in unneeded folders ([#10])

Added
- Added badges to readme ([#8])

[#7]: https://github.com/PurpleBooth/jira-branch-helper/pull/7
[#8]: https://github.com/PurpleBooth/jira-branch-helper/pull/8
[#9]: https://github.com/PurpleBooth/jira-branch-helper/pull/9
[#10]: https://github.com/PurpleBooth/jira-branch-helper/pull/10